### PR TITLE
Allow securityContext to be specified in values.yaml

### DIFF
--- a/moon/templates/moon.yaml
+++ b/moon/templates/moon.yaml
@@ -132,6 +132,10 @@ spec:
       labels:
         app: moon
     spec:
+      {{- with .Values.moon.securityContext }}
+      securityContext:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.moon.nodeSelector }}
       nodeSelector:
         {{- range $key, $value := .Values.moon.nodeSelector }}

--- a/moon/values.yaml
+++ b/moon/values.yaml
@@ -25,6 +25,12 @@ moon:
 #  nodeSelector:
 #    kubernetes.io/os: linux
 
+## If specified, the pod's security policies.
+## ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+##
+#  securityContext: 
+#    runAsUser: 1000
+
 ## Assign custom affinity rules to the instance
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
 ##


### PR DESCRIPTION
Our kubernetes cluster is fairly locked down - had to specify runAsUser: 1000 to get this to work.