### PR TITLE
Add ability to set loadBalancerIP on service

### DIFF
--- a/moon/templates/moon.yaml
+++ b/moon/templates/moon.yaml
@@ -78,7 +78,7 @@ spec:
   type: {{ .Values.moon.service.type }}
   {{- if .Values.moon.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.moon.service.loadBalancerIP }}
-  {{- end }
+  {{- end }}
   {{- with .Values.moon.service.externalIPs }}
   externalIPs:
   {{- range . }}

--- a/moon/templates/moon.yaml
+++ b/moon/templates/moon.yaml
@@ -76,6 +76,9 @@ spec:
     protocol: TCP
     port: 8080
   type: {{ .Values.moon.service.type }}
+  {{- if .Values.moon.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.moon.service.loadBalancerIP }}
+  {{- end }
   {{- with .Values.moon.service.externalIPs }}
   externalIPs:
   {{- range . }}

--- a/moon/values.yaml
+++ b/moon/values.yaml
@@ -160,6 +160,7 @@ moon:
     annotations: {}
     labels: {}
     type: LoadBalancer
+#    loadBalancerIP: 1.2.3.4
 #    externalIPs: []
 
   ##


### PR DESCRIPTION
We'd like to set a static external IP on the Moon service so that the IP does not change in case the cluster gets rebuild.

For GCP the use of this feature is documented here: https://cloud.google.com/kubernetes-engine/docs/tutorials/configuring-domain-name-static-ip#use_a_service

Right now we achieve this by creating an additional service, but it would be great if this can become part of the Helm chart.

