### PR TITLE
Do not add priorityClassName in case it's not set in values

### DIFF
--- a/moon/Chart.yaml
+++ b/moon/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: moon
-version: 1.1.14
+version: 1.1.16
 appVersion: 1.9.2
 description: Moon Helm chart
 icon: https://aerokube.com/img/aerokube_logo.svg

--- a/moon/templates/deployment.yaml
+++ b/moon/templates/deployment.yaml
@@ -33,7 +33,9 @@ spec:
         {{ toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ .Release.Name }}
-      priorityClassName: {{ .Values.moon.priorityClassName | default "default" }}
+      {{- if .Values.moon.priorityClassName }}
+      priorityClassName: {{ .Values.moon.priorityClassName }}
+      {{- end }}
       containers:
       - name: moon
         {{- if .Values.moon.image }}


### PR DESCRIPTION
Currently if `.Values.moon.priorityClassName` is not set then  
```yaml
...
      priorityClassName: "default"
...
```
is set. 

Priority class name "default" might be missing in k8s clusters, e.g. my EKS cluster does not have it. So the chart installation failed due to missing priority class.

With changes in this PR `priorityClassName:` won't be set in case it is not specified in values