### PR TITLE
Add resources for cron-jobs

### DIFF
--- a/browser-ops/templates/cron-job.yaml
+++ b/browser-ops/templates/cron-job.yaml
@@ -37,4 +37,9 @@ spec:
               value: {{ .Values.browserImageVersions | quote }}
             {{- end }}
             {{- end }}
+            {{- if .Values.resources }}
+            resources:
+              {{- toYaml .Values.resources | nindent 14 }}
+            {{- end }}
           restartPolicy: Never
+

--- a/browser-ops/values.yaml
+++ b/browser-ops/values.yaml
@@ -20,3 +20,9 @@ browserImageVersions: recent
 ## Schedule
 ##
 schedule: "0 1 * * *"
+
+##
+## Resources
+##
+resources: {}
+

--- a/license-ops/templates/cron-job.yaml
+++ b/license-ops/templates/cron-job.yaml
@@ -18,4 +18,10 @@ spec:
             image: bitnami/kubectl:{{ .Values.version }}
             command: ["/bin/bash", "-c"]
             args: ["kubectl patch license {{ .Values.licenseName }} --type='json' -p=\"[{\\\"op\\\": \\\"replace\\\", \\\"path\\\": \\\"/spec/data\\\", \\\"value\\\":\\\"$(kubectl get secret {{ .Values.secretName }} -n {{ .Release.Namespace }} -o yaml -o=jsonpath='{.data.license\\.key}' | base64 -d)\\\"}]\""]
+            {{- if .Values.resources }}
+            resources:
+              {{- toYaml .Values.resources | nindent 14 }}
+            {{- end }}
           restartPolicy: Never
+
+

--- a/license-ops/values.yaml
+++ b/license-ops/values.yaml
@@ -18,3 +18,9 @@ schedule: "* * * * *"
 ##
 version: 1.23
 
+##
+## Resources
+##
+resources: {}
+
+


### PR DESCRIPTION
Adding the opportunity to configure cron-jobs with resources in the case when local k8s policy doesn't allow to use helm charts without resources