### PR TITLE
Make it possible to provide pod annotations

### DIFF
--- a/moon2/templates/deployment.yaml
+++ b/moon2/templates/deployment.yaml
@@ -20,6 +20,10 @@ spec:
       app: {{ .Release.Name }}
   template:
     metadata:
+      annotations:
+        {{- range $key, $value := .Values.pod.annotations }}
+          {{ $key }}: {{ $value | quote }}
+        {{- end }}
       labels:
         app: {{ .Release.Name }}
     spec:

--- a/moon2/templates/deployment.yaml
+++ b/moon2/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        {{- range $key, $value := .Values.pod.podAnnotations }}
+        {{- range $key, $value := .Values.deploymnet.podAnnotations }}
           {{ $key }}: {{ $value | quote }}
         {{- end }}
       labels:

--- a/moon2/templates/deployment.yaml
+++ b/moon2/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        {{- range $key, $value := .Values.deploymnet.podAnnotations }}
+        {{- range $key, $value := .Values.deployment.podAnnotations }}
           {{ $key }}: {{ $value | quote }}
         {{- end }}
       labels:

--- a/moon2/templates/deployment.yaml
+++ b/moon2/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        {{- range $key, $value := .Values.pod.annotations }}
+        {{- range $key, $value := .Values.pod.podAnnotations }}
           {{ $key }}: {{ $value | quote }}
         {{- end }}
       labels:

--- a/moon2/values.yaml
+++ b/moon2/values.yaml
@@ -116,21 +116,6 @@ service:
   ##
   externalIPs: []
 
-
-##
-## Moon pod-deployment settings.
-## 
-pod:
-  ##
-  ## Custom deployment annotations.
-  ##
-  annotations: {}
-
-  ##
-  ## Custom pod annotations.
-  ##
-  podAnnotations: {}
-
 ##
 ## Moon deployment settings.
 ##
@@ -140,6 +125,11 @@ deployment:
   ## Custom deployment annotations.
   ##
   annotations: {}
+
+  ##
+  ## Custom pod annotations.
+  ##
+  podAnnotations: {}
 
   ##
   ## Total number of Moon pods. Default is 2.

--- a/moon2/values.yaml
+++ b/moon2/values.yaml
@@ -126,6 +126,11 @@ pod:
   ##
   annotations: {}
 
+  ##
+  ## Custom pod annotations.
+  ##
+  podAnnotations: {}
+
 ##
 ## Moon deployment settings.
 ##

--- a/moon2/values.yaml
+++ b/moon2/values.yaml
@@ -116,6 +116,16 @@ service:
   ##
   externalIPs: []
 
+
+##
+## Moon pod-deployment settings.
+## 
+pod:
+  ##
+  ## Custom deployment annotations.
+  ##
+  annotations: {}
+
 ##
 ## Moon deployment settings.
 ##


### PR DESCRIPTION
Make it possible to provide pod annotations. Otherwise it's not possible to prevent autoscaling evicting not to be applied: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node