### PR TITLE
Add custom pod annotations for deployment template

### DIFF
--- a/moon2/templates/deployment.yaml
+++ b/moon2/templates/deployment.yaml
@@ -20,6 +20,10 @@ spec:
       app: {{ .Release.Name }}
   template:
     metadata:
+      annotations:
+        {{- range $key, $value := .Values.deployment.podAnnotations }}
+          {{ $key }}: {{ $value | quote }}
+        {{- end }}
       labels:
         app: {{ .Release.Name }}
     spec:

--- a/moon2/values.yaml
+++ b/moon2/values.yaml
@@ -127,6 +127,11 @@ deployment:
   annotations: {}
 
   ##
+  ## Custom pod annotations for deployment template.
+  ##
+  podAnnotations: {}
+
+  ##
   ## Total number of Moon pods. Default is 2.
   ##
   replicas:


### PR DESCRIPTION
I want to provide some prometheus/vmetrics annotations to moon pods. I think my fix would be good for this.