### PR TITLE
Chart apiVersion should be v2 because we require Helm 3

### DIFF
--- a/browser-ops/Chart.yaml
+++ b/browser-ops/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: browser-ops
 version: 1.0.0
 appVersion: 2.3.7

--- a/license-ops/Chart.yaml
+++ b/license-ops/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: license-ops
 version: 1.0.0
 appVersion: 1.0.1

--- a/moon/Chart.yaml
+++ b/moon/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: moon
 version: 1.1.28
 appVersion: 1.9.8

--- a/moon2/Chart.yaml
+++ b/moon2/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: moon2
 version: 2.0.0
 appVersion: 2.4.5


### PR DESCRIPTION
https://helm.sh/docs/topics/charts/#the-apiversion-field