### PR TITLE
allow disabling the creation of namespaces defined in quotas

### DIFF
--- a/moon2/templates/namespaces.yaml
+++ b/moon2/templates/namespaces.yaml
@@ -3,7 +3,7 @@
 {{- if or (not $quota) (not $quota.namespace) }}
 {{- fail (printf "quota %s namespace is not set" $name) }}
 {{- end }}
-{{- if ne $quota.namespace $releaseNamespace }}
+{{- if and (ne $quota.createNamespace false) (ne $quota.namespace $releaseNamespace) }}
 ---
 apiVersion: v1
 kind: Namespace


### PR DESCRIPTION
In our environment, namespaces are provisioned from information pulled from our IAM system. This causes conflicts with the moon2 chart which expects to be able to make the namespace referenced in the quota values, which will already exist.

This PR adds a `createNamespace`  boolean value to each quota definition that allows for disabling the creation of the namespace. The value defaults to `true` to maintain backwards compatibility for users who do not set the value.

In the following example, the `alpha` namespace will NOT be created and the `beta` and `gamma` namespaces WILL be created:
```
quota:
  moon: null
  alpha-team:
    namespace: alpha
    createNamespace: false
  beta-team:
    namespace: beta
    createNamespace: true
  gamma-team:
    namespace: gamma
```